### PR TITLE
Update YNSearchMainView.swift

### DIFF
--- a/YNSearch/YNSearchMainView.swift
+++ b/YNSearch/YNSearchMainView.swift
@@ -133,7 +133,7 @@ open class YNSearchMainView: UIView {
             ynSearchHistoryButtons.append(view.ynSearchHistoryButton)
             self.addSubview(view)
         }
-        guard let lastHistoryView = self.ynSearchHistoryViews.last else { return }
+        let lastHistoryView = self.ynSearchHistoryViews.last ?? searchHistoryLabelOriginY
         
         self.clearHistoryButton = UIButton(frame: CGRect(x: margin, y: lastHistoryView.frame.origin.y + lastHistoryView.frame.height, width: width - (margin * 2), height: 40))
         self.clearHistoryButton.setTitle("Clear search history", for: .normal)


### PR DESCRIPTION
shouldn't guard in init function, or will cause clearHistoryButton cannot construct.